### PR TITLE
Apr1/NT rep glows in the dark

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -22,6 +22,11 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: PointLight
+        enabled: true
+        radius: 1.5
+        energy: 2
+        color: "#32CD32"
 
 - type: startingGear
   id: NanotrasenRepresentativeGear
@@ -30,7 +35,7 @@
     back: ClothingBackpackFilled
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatCentcomcap
-    eyes: ClothingEyesGlasses  
+    eyes: ClothingEyesGlasses
     id: CentcomPDA
     ears: ClothingHeadsetCentCom
     belt: BoxFolderCentComClipboard


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

<img width="647" alt="image" src="https://github.com/Verbalase/Goob-Station/assets/109166122/78093d69-c317-4a6d-a188-5604868bbf84">

:cl: Marsey
- add: NT representatives are now showing their true color
